### PR TITLE
gh-13: Updates CI to use Node 18.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v4
       with:
-        node-version: '14'
+        node-version: '18'
 
     - name: Set up Buildx
       id: buildx


### PR DESCRIPTION
This may not fix our CI issues, but seems like a good place to start. Node 18 is the last LTE version that is compatible with Snowpack, so we'll have to stick with it until we migrate to Vite some day.