### PR TITLE
Fixes gh-16: Redraws room SVG when device orientation changes.

### DIFF
--- a/src/room.js
+++ b/src/room.js
@@ -121,6 +121,12 @@ export class SpatialRoom extends EventTarget {
 
       // Redraw sound field when the screen is resized
       window.addEventListener('resize', _.bind(this.redraw, this))
+
+      // Also redraw whenever the screen orientation changes.
+      if (typeof(screen) !== "undefined" && screen.orientation) {
+         screen.orientation.addEventListener('change',
+            _.bind(this.redraw, this));
+      }
    }
 
    enableAudio() {


### PR DESCRIPTION
This PR replaces #17 with a slightly better implementation in a single, signed commit. I've tested this fix in the Audimance app and Safari on iOS, and in Chrome and Firefox on Android.