### PR TITLE
gh-28: Wraps media setup logic in a one-off canplay listener.

### DIFF
--- a/src/room.js
+++ b/src/room.js
@@ -368,15 +368,19 @@ class Track {
       src.setMaxDistance(AudioMaxDistance)
 
       // Toggle play once to initialise mobile playback
-      let playPromise = el.play()
-      if (playPromise !== undefined) {
-         playPromise.then(_ => {
-            el.pause()
-         })
-         .catch(error => {
-            console.error("pause for source "+s.id+" track "+ index + " failed", error, error.stack)
-         })
-      }
+      el.addEventListener("canplay", () => {
+         let playPromise = el.play()
+         if (playPromise !== undefined) {
+            playPromise.then(_ => {
+               el.pause()
+            })
+            .catch(error => {
+               console.error("pause for source "+s.id+" track "+ index + " failed", error, error.stack)
+            })
+         }
+      }, {
+         once: true
+      })
 
       let lastSync = Date.now()
       performanceTime.addEventListener('timeSync', function() {


### PR DESCRIPTION
I've tested this in the Audimance iOS app and in Safari on iOS, but haven't yet had a workable Wi-Fi network to test on Android.